### PR TITLE
Update band combination aliases as detailed in stac-spec.

### DIFF
--- a/app/MapScreen.js
+++ b/app/MapScreen.js
@@ -11,9 +11,9 @@ import queryString from 'query-string';
 import Config from 'react-native-config';
 
 const bandCombinations = {
-  natural: 'red,green,blue',
-  vegetationHealth: 'nir,swir16,blue',
-  landWater: 'nir,swir16,red',
+  natural: 'B4,B3,B2',
+  vegetationHealth: 'B5,B6,B2',
+  landWater: 'B5,B6,B4',
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
See [common-band-names](https://github.com/radiantearth/stac-spec/blob/master/extensions/stac-eo-spec.md#common-band-names).  The [sat-api](https://github.com/sat-utils/sat-api) now uses these [keys](https://github.com/radiantearth/stac-spec/blob/master/json-spec/examples/landsat8-sample.json#L80) for bands within its `assets` object.